### PR TITLE
Compiler issue with return value fixed

### DIFF
--- a/src/RCWL_1X05.cpp
+++ b/src/RCWL_1X05.cpp
@@ -156,6 +156,7 @@ uint32_t RCWL_1X05::read() {
       break;
     }
   }
+  return 0; 
 }
 
 


### PR DESCRIPTION
While working with this library i came across very simple to fix issue with compiling the code for esp8266.
Compiler said that it's missing a return value outside switch case i read method so i added it.
Here is the compiler log:

```
Compiling .pio/build/esp8266/libf2e/RCWL_1X05/RCWL_1X05.cpp.o
.pio/libdeps/esp8266/RCWL_1X05/src/RCWL_1X05.cpp: In member function 'uint32_t RCWL_1X05::read()':
.pio/libdeps/esp8266/RCWL_1X05/src/RCWL_1X05.cpp:160:1: error: control reaches end of non-void function [-Werror=return-type]
  160 | }
      | ^
cc1plus: some warnings being treated as errors
*** [.pio/build/esp8266/libf2e/RCWL_1X05/RCWL_1X05.cpp.o] Error 1
```